### PR TITLE
Add support for custom providers

### DIFF
--- a/unicorn/provider/com.github.gist.lua
+++ b/unicorn/provider/com.github.gist.lua
@@ -1,0 +1,13 @@
+local unicorn = dofile("/lib/unicorn/init.lua")
+-- Package provider for GitHub Gists <gists.github.com>.
+-- @param package_table table A valid package table
+local function install_gist(package_table)
+	-- this is really simple, only works predictably with a one-file gist.
+	for k,v in pairs(package_table.instdat.filemaps) do
+		-- uses source code repository-like names because a Gist is a repository technically :)
+		local http_data = unicorn.util.smartHttp("https://gist.githubusercontent.com/" .. package_table.instdat.repo_owner .."/"..  package_table.instdat.repo_name .."/raw/"..package_table.instdat.repo_ref.."/"..k)
+		unicorn.util.fileWrite(http_data, v)
+	end
+end
+
+return install_gist

--- a/unicorn/provider/com.github.lua
+++ b/unicorn/provider/com.github.lua
@@ -1,0 +1,12 @@
+local unicorn = dofile("/lib/unicorn/init.lua")
+
+--- Package provider for GitHub.com.
+-- @param package_table table A valid package table
+local function install_github(package_table)
+	for k,v in pairs(package_table.instdat.filemaps) do
+		local http_data = unicorn.util.smartHttp("https://raw.githubusercontent.com/" .. package_table.instdat.repo_owner .."/".. package_table.instdat.repo_name .."/".. package_table.instdat.repo_ref .."/".. k)
+		unicorn.util.fileWrite(http_data, v)
+	end
+end
+
+return install_github

--- a/unicorn/provider/com.gitlab.lua
+++ b/unicorn/provider/com.gitlab.lua
@@ -1,0 +1,10 @@
+local unicorn = dofile("/lib/unicorn/init.lua")
+
+--- Package provider for GitLab.com.
+-- @param package_table table A valid package table
+local function install_gitlab(package_table)
+	for k,v in pairs(package_table.instdat.filemaps) do
+		local http_data = unicorn.util.smartHttp("https://gitlab.com/raw/" .. package_table.instdat.repo_owner .."/".. package_table.instdat.repo_name .."/".. package_table.instdat.repo_ref .."/".. k)
+		unicorn.util.fileWrite(http_data, v)
+	end
+end

--- a/unicorn/provider/com.pastebin.lua
+++ b/unicorn/provider/com.pastebin.lua
@@ -1,0 +1,12 @@
+local unicorn = dofile("/lib/unicorn/init.lua")
+
+--- Package provider for Pastebin.com.
+-- @param package_table table A valid package table
+local function install_pastebin(package_table)
+	for k,v in pairs(package_table.instdat.filemaps) do
+		local http_data = unicorn.util.smartHttp("https://pastebin.com/raw/" .. k)
+		unicorn.util.fileWrite(http_data, v)
+	end
+end
+
+return install_pastebin

--- a/unicorn/provider/dev.devbin.lua
+++ b/unicorn/provider/dev.devbin.lua
@@ -1,0 +1,12 @@
+local unicorn = dofile("/lib/unicorn/init.lua")
+
+--- Package provider for Devbin.dev.
+-- @param package_table table A valid package table
+local function install_devbin(package_table)
+	for k,v in pairs(package_table.instdat.filemaps) do
+		local http_data = unicorn.util.smartHttp("https://devbin.dev/raw/" .. k)
+		unicorn.util.fileWrite(http_data, v)
+	end
+end
+
+return install_devbin

--- a/unicorn/provider/org.bitbucket.lua
+++ b/unicorn/provider/org.bitbucket.lua
@@ -1,0 +1,12 @@
+local unicorn = dofile("/lib/unicorn/init.lua")
+
+--- Package provider for Bitbucket.org.
+-- @param package_table table A valid package table
+local function install_bitbucket(package_table)
+	for k,v in pairs(package_table.instdat.filemaps) do
+		local http_data = unicorn.util.smartHttp("https://bitbucket.org/raw/" .. package_table.instdat.repo_owner .."/".. package_table.instdat.repo_name .."/".. package_table.instdat.repo_ref .."/".. k)
+		unicorn.util.fileWrite(http_data, v)
+	end
+end
+
+return install_bitbucket


### PR DESCRIPTION
Adds support for custom providers by dropping them in `/lib/unicorn/provider`.

Stuff we need to do before this merges:

- [x] Update documentation (done in 39bbc94)